### PR TITLE
Port over to using futures-rs underneath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/rockneurotiko/async-await"
 keywords = ["async", "future", "await", "thread"]
 
 [dependencies]
-eventual = "0.1.5"
+futures = "0.1.1"


### PR DESCRIPTION
Carl Lerche has deprecated Eventual in favor of futures-rs.
(can be found at the top of the readme)
https://github.com/carllerche/eventual

This PR ports the functionality over to using futures-rs underneath.

I think another feature add that might be better separate from this PR would be to allow it to use a futures_cpupool or mio event loop reference passed in.

Let me know what you think. Thanks.
