### PR TITLE
Basic implementation that allows a cpu pool to be used.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ keywords = ["async", "future", "await", "thread"]
 
 [dependencies]
 futures = "0.1.1"
+futures-cpupool = "0.1"


### PR DESCRIPTION
Hi again,

I have another PR for you. I also didn't like the idea of spawning a thread on every async request.

I'm not sure this is the best option, but it at least allows the user to pass a cpupool to do the work on instead.

If you agree that this is an adequate solution for now, let me know and I can update the Readme as well.

Thanks.